### PR TITLE
Add required packages min versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,11 @@ install it on Python {}.{}.
 
 setup(
     name="mod-net",
-    version="v2.0.0-beta3",
+    version="v2.0.0-beta4",
     description="Make SET and SEU fault injections in hierarchical verilog netlists",
     packages=find_packages(exclude=("tests",)),
     install_requires=[
-        'Click',
+        'Click>=7.1.2',
     ],
     entry_points={
         'console_scripts': ['modnet=modnet.cli:main'],

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     description="Make SET and SEU fault injections in hierarchical verilog netlists",
     packages=find_packages(exclude=("tests",)),
     install_requires=[
-        'Click>=7.1.2',
+        'Click==7.*',
     ],
     entry_points={
         'console_scripts': ['modnet=modnet.cli:main'],


### PR DESCRIPTION
The official python documentation considers a best practice NOT to fixed the exact version, but rather de minimal version required for a package:

https://packaging.python.org/discussions/install-requires-vs-requirements/

> It is not considered best practice to use install_requires to pin dependencies to specific versions, or to specify sub-dependencies (i.e. dependencies of your dependencies). This is overly-restrictive, and prevents the user from gaining the benefit of dependency upgrades.